### PR TITLE
cmd: allow the app to properly stop

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const maxRestartAttempt = 100
+const maxRestartAttempt = 60
 
 func StartCmd() *cobra.Command {
 	return &cobra.Command{
@@ -44,8 +44,8 @@ func StartCmd() *cobra.Command {
 			err = app.Start()
 			for restartAttempt := 0; restartAttempt < maxRestartAttempt && err != nil; restartAttempt++ {
 				fmt.Println(err)
+				fmt.Printf("Attempting restart again in a minute (attempt %d of %d)...\n", restartAttempt+1, maxRestartAttempt)
 				time.Sleep(time.Minute)
-				fmt.Println("Attempting restart again...")
 				err = app.Start()
 			}
 			return nil

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -11,6 +11,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const maxRestartAttempt = 100
+
 func StartCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "start",
@@ -39,14 +41,17 @@ func StartCmd() *cobra.Command {
 				return err
 			}
 
-			for {
-				err := app.Start()
+			restartAttempt := 0
+			err = app.Start()
+			for restartAttempt < maxRestartAttempt {
 				if err != nil {
 					fmt.Println(err)
 					time.Sleep(time.Minute)
 					fmt.Println("Attempting restart again...")
+					err = app.Start()
 				}
 			}
+			return nil
 		},
 	}
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -41,15 +41,12 @@ func StartCmd() *cobra.Command {
 				return err
 			}
 
-			restartAttempt := 0
 			err = app.Start()
-			for restartAttempt < maxRestartAttempt {
-				if err != nil {
-					fmt.Println(err)
-					time.Sleep(time.Minute)
-					fmt.Println("Attempting restart again...")
-					err = app.Start()
-				}
+			for restartAttempt := 0; restartAttempt < maxRestartAttempt && err != nil; restartAttempt++ {
+				fmt.Println(err)
+				time.Sleep(time.Minute)
+				fmt.Println("Attempting restart again...")
+				err = app.Start()
 			}
 			return nil
 		},

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -11,10 +11,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const maxRestartAttempt = 60
+const defaultMaxRestartAttempt = 60
 
 func StartCmd() *cobra.Command {
-	return &cobra.Command{
+	cmd := &cobra.Command{
 		Use:   "start",
 		Short: "Starts the provider",
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -26,6 +26,14 @@ func StartCmd() *cobra.Command {
 			logLevel, err := cmd.Flags().GetString(types.FlagLogLevel)
 			if err != nil {
 				return err
+			}
+
+			maxRestartAttempt, err := cmd.Flags().GetInt("restart-attempt")
+			if err != nil {
+				return err
+			}
+			if maxRestartAttempt < 0 {
+				maxRestartAttempt = 0
 			}
 
 			if logLevel == "info" {
@@ -42,6 +50,7 @@ func StartCmd() *cobra.Command {
 			}
 
 			err = app.Start()
+
 			for restartAttempt := 0; restartAttempt < maxRestartAttempt && err != nil; restartAttempt++ {
 				fmt.Println(err)
 				fmt.Printf("Attempting restart again in a minute (attempt %d of %d)...\n", restartAttempt+1, maxRestartAttempt)
@@ -51,4 +60,7 @@ func StartCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().Int("restart-attempt", defaultMaxRestartAttempt, "attempt to restart <restart-attempt> times when the provider fails to start")
+	return cmd
 }

--- a/core/app.go
+++ b/core/app.go
@@ -188,9 +188,7 @@ func (a *App) Start() error {
 
 		totalSpace, err := strconv.ParseInt(res.Provider.Totalspace, 10, 64)
 		if err != nil {
-			if err != nil {
-				return err
-			}
+			return err
 		}
 		if totalSpace != cfg.TotalSpace {
 			err := updateSpace(w, cfg.TotalSpace)
@@ -230,6 +228,8 @@ func (a *App) Start() error {
 	go a.monitor.Start()
 
 	done := make(chan os.Signal, 1)
+	defer signal.Stop(done) //undo signal.Notify effect
+
 	signal.Notify(done, syscall.SIGINT, syscall.SIGTERM)
 	<-done // Will block here until user hits ctrl+c
 


### PR DESCRIPTION
sequoia was unable to stop even with SIGTERM because the signal is captured at core module to shutdown module gracefully. Thus, the signal is not passed through to cmd and cmd restarts core forever. To fix this issue, the core is restarted only when it returns an error. There is also max restart attempt so it doesn't run forever.