### PR TITLE
fix db crash when data grows to 1.1TB

### DIFF
--- a/core/app.go
+++ b/core/app.go
@@ -60,6 +60,7 @@ func NewApp(home string) (*App, error) {
 
 	options.Logger = &logger.SequoiaLogger{}
 	options.BlockCacheSize = 256 << 25
+	options.MaxLevels = 8
 
 	db, err := badger.Open(options)
 	if err != nil {


### PR DESCRIPTION
badger db will crash when stored data reaches ~ 1.1TB. Increasing compaction level to level 8 should increase the maximum size.