### PR TITLE
Viper config

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func init() {
@@ -156,6 +157,18 @@ func RootCmd() *cobra.Command {
 
 	r.PersistentFlags().String(types.FlagHome, types.DefaultHome, "sets the home directory for sequoia")
 	r.PersistentFlags().String(types.FlagLogLevel, types.DefaultLogLevel, "log level. info|error|debug")
+	r.PersistentFlags().Int("restart-attempt", defaultMaxRestartAttempt, "attempt to restart <restart-attempt> times when the provider fails to start")
+	r.PersistentFlags().String("domain", "http://example.com", "provider comain")
+	r.PersistentFlags().Int64("api_config.port", 3333, "port to serve api requests")
+	r.PersistentFlags().Int("api_config.ipfs_port", 4005, "port for IPFS")
+	r.PersistentFlags().String("api_config.ipfs_domain", "dns4/ipfs.example.com/tcp/4001", "IPFS domain")
+	r.PersistentFlags().Int64("proof_threads", 1000, "maximum threads for proofs")
+	r.PersistentFlags().String("data_directory", "$HOME/.sequoia/data", "directory to store database files")
+	r.PersistentFlags().Int64("queue_interval", 10, "seconds to wait until next cycle to flush the transaction queue")
+	r.PersistentFlags().Int64("proof_interval", 120, "seconds to wait until next cycle to post proofs")
+	r.PersistentFlags().Int64("total_bytes_offered", 1092616192, "maximum storage space to provide in bytes")
+
+	viper.BindPFlags(r.PersistentFlags())
 
 	r.AddCommand(StartCmd(), wallet.WalletCmd(), InitCmd(), VersionCmd(), IPFSCmd(), SalvageCmd(), ShutdownCmd())
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -168,7 +168,10 @@ func RootCmd() *cobra.Command {
 	r.PersistentFlags().Int64("proof_interval", 120, "seconds to wait until next cycle to post proofs")
 	r.PersistentFlags().Int64("total_bytes_offered", 1092616192, "maximum storage space to provide in bytes")
 
-	viper.BindPFlags(r.PersistentFlags())
+	err := viper.BindPFlags(r.PersistentFlags())
+	if err != nil {
+		panic(err)
+	}
 
 	r.AddCommand(StartCmd(), wallet.WalletCmd(), InitCmd(), VersionCmd(), IPFSCmd(), SalvageCmd(), ShutdownCmd())
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -63,15 +63,15 @@ func StartCmd() *cobra.Command {
 	}
 
 	cmd.Flags().Int("restart-attempt", defaultMaxRestartAttempt, "attempt to restart <restart-attempt> times when the provider fails to start")
-	cmd.Flags().String("ip", "http://example.com", "provider comain")
-	cmd.Flags().Int64("apicfg.port", 3333, "port to serve api requests")
-	cmd.Flags().Int("apicfg.ipfsport", 4005, "port for IPFS")
-	cmd.Flags().String("apicfg.ipfsdomain", "dns4/ipfs.example.com/tcp/4001", "IPFS domain")
-	cmd.Flags().Int64("proofthreads", 1000, "maximum threads for proofs")
-	cmd.Flags().String("datadirectory", "$HOME/.sequoia/data", "directory to store database files")
-	cmd.Flags().Int64("queueinterval", 10, "seconds to wait until next cycle to flush the transaction queue")
-	cmd.Flags().Int64("proofinterval", 120, "seconds to wait until next cycle to post proofs")
-	cmd.Flags().Int64("totalspace", 1092616192, "maximum storage space to provide in bytes")
+	cmd.Flags().String("domain", "http://example.com", "provider comain")
+	cmd.Flags().Int64("api_config.port", 3333, "port to serve api requests")
+	cmd.Flags().Int("api_config.ipfs_port", 4005, "port for IPFS")
+	cmd.Flags().String("api_config.ipfs_domain", "dns4/ipfs.example.com/tcp/4001", "IPFS domain")
+	cmd.Flags().Int64("proof_threads", 1000, "maximum threads for proofs")
+	cmd.Flags().String("data_directory", "$HOME/.sequoia/data", "directory to store database files")
+	cmd.Flags().Int64("queue_interval", 10, "seconds to wait until next cycle to flush the transaction queue")
+	cmd.Flags().Int64("proof_interval", 120, "seconds to wait until next cycle to post proofs")
+	cmd.Flags().Int64("total_bytes_offered", 1092616192, "maximum storage space to provide in bytes")
 
 	viper.BindPFlags(cmd.Flags())
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 const defaultMaxRestartAttempt = 60
@@ -62,5 +63,17 @@ func StartCmd() *cobra.Command {
 	}
 
 	cmd.Flags().Int("restart-attempt", defaultMaxRestartAttempt, "attempt to restart <restart-attempt> times when the provider fails to start")
+	cmd.Flags().String("ip", "http://example.com", "provider comain")
+	cmd.Flags().Int64("apicfg.port", 3333, "port to serve api requests")
+	cmd.Flags().Int("apicfg.ipfsport", 4005, "port for IPFS")
+	cmd.Flags().String("apicfg.ipfsdomain", "dns4/ipfs.example.com/tcp/4001", "IPFS domain")
+	cmd.Flags().Int64("proofthreads", 1000, "maximum threads for proofs")
+	cmd.Flags().String("datadirectory", "$HOME/.sequoia/data", "directory to store database files")
+	cmd.Flags().Int64("queueinterval", 10, "seconds to wait until next cycle to flush the transaction queue")
+	cmd.Flags().Int64("proofinterval", 120, "seconds to wait until next cycle to post proofs")
+	cmd.Flags().Int64("totalspace", 1092616192, "maximum storage space to provide in bytes")
+
+	viper.BindPFlags(cmd.Flags())
+
 	return cmd
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -9,7 +9,6 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 const defaultMaxRestartAttempt = 60
@@ -61,19 +60,6 @@ func StartCmd() *cobra.Command {
 			return nil
 		},
 	}
-
-	cmd.Flags().Int("restart-attempt", defaultMaxRestartAttempt, "attempt to restart <restart-attempt> times when the provider fails to start")
-	cmd.Flags().String("domain", "http://example.com", "provider comain")
-	cmd.Flags().Int64("api_config.port", 3333, "port to serve api requests")
-	cmd.Flags().Int("api_config.ipfs_port", 4005, "port for IPFS")
-	cmd.Flags().String("api_config.ipfs_domain", "dns4/ipfs.example.com/tcp/4001", "IPFS domain")
-	cmd.Flags().Int64("proof_threads", 1000, "maximum threads for proofs")
-	cmd.Flags().String("data_directory", "$HOME/.sequoia/data", "directory to store database files")
-	cmd.Flags().Int64("queue_interval", 10, "seconds to wait until next cycle to flush the transaction queue")
-	cmd.Flags().Int64("proof_interval", 120, "seconds to wait until next cycle to post proofs")
-	cmd.Flags().Int64("total_bytes_offered", 1092616192, "maximum storage space to provide in bytes")
-
-	viper.BindPFlags(cmd.Flags())
 
 	return cmd
 }

--- a/config/config.go
+++ b/config/config.go
@@ -31,8 +31,7 @@ func ReadConfig(data []byte) (*Config, error) {
 	// not using a default config to detect badger ds users
 	config := Config{}
 
-	err := yaml.Unmarshal(data, &config)
-	if err != nil {
+	if err := yaml.Unmarshal(data, &config); err != nil {
 		return nil, err
 	}
 

--- a/config/files.go
+++ b/config/files.go
@@ -76,9 +76,16 @@ func Init(home string) (*Config, error) {
 		return nil, err
 	}
 
-	err = createFiles(directory)
-	if err != nil {
-		return nil, err
+	viper.SetConfigName(ConfigFileName)
+	viper.AddConfigPath(directory)
+
+	if err := viper.ReadInConfig(); err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+			err := createFiles(directory)
+			if err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	config, err := ReadConfigFile(directory)

--- a/config/files.go
+++ b/config/files.go
@@ -9,7 +9,11 @@ import (
 	"github.com/spf13/viper"
 )
 
-const ConfigFileName = "config.yaml"
+const (
+	ConfigName     = "config"
+	ConfigType     = "yaml"
+	ConfigFileName = ConfigName + "." + ConfigType
+)
 
 func createIfNotExists(directory string, fileName string, contents []byte) (bool, error) {
 	filePath := path.Join(directory, fileName)
@@ -76,7 +80,8 @@ func Init(home string) (*Config, error) {
 		return nil, err
 	}
 
-	viper.SetConfigName(ConfigFileName)
+	viper.SetConfigName(ConfigName)
+	viper.SetConfigType(ConfigType)
 	viper.AddConfigPath(directory)
 
 	if err := viper.ReadInConfig(); err != nil {
@@ -85,13 +90,17 @@ func Init(home string) (*Config, error) {
 			if err != nil {
 				return nil, err
 			}
+		} else {
+			return nil, err
 		}
 	}
-
-	config, err := ReadConfigFile(directory)
-	if err != nil {
-		return nil, err
-	}
+	/*
+		config, err := ReadConfigFile(directory)
+		if err != nil {
+			return nil, err
+		}
+	*/
+	var config Config
 
 	if err := viper.Unmarshal(&config); err != nil {
 		return nil, err
@@ -99,5 +108,5 @@ func Init(home string) (*Config, error) {
 
 	log.Debug().Object("config", config)
 
-	return config, nil
+	return &config, nil
 }

--- a/config/files.go
+++ b/config/files.go
@@ -4,6 +4,9 @@ import (
 	"errors"
 	"os"
 	"path"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/viper"
 )
 
 const ConfigFileName = "config.yaml"
@@ -62,7 +65,6 @@ func ReadConfigFile(directory string) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-
 	return config, nil
 }
 
@@ -79,5 +81,16 @@ func Init(home string) (*Config, error) {
 		return nil, err
 	}
 
-	return ReadConfigFile(directory)
+	config, err := ReadConfigFile(directory)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := viper.Unmarshal(&config); err != nil {
+		return nil, err
+	}
+
+	log.Debug().Object("config", config)
+
+	return config, nil
 }

--- a/config/wallet.go
+++ b/config/wallet.go
@@ -7,6 +7,7 @@ import (
 
 	sequoiaWallet "github.com/JackalLabs/sequoia/wallet"
 	bip39 "github.com/cosmos/go-bip39"
+	"github.com/desmos-labs/cosmos-go-wallet/types"
 	"github.com/desmos-labs/cosmos-go-wallet/wallet"
 
 	jsoniter "github.com/json-iterator/go"
@@ -94,7 +95,7 @@ func InitWallet(home string) (*wallet.Wallet, error) {
 	legacyWallet, err := detectLegacyWallet(home)
 	if err == nil {
 		log.Info().Msg("legacy wallet detected")
-		return sequoiaWallet.CreateWalletPrivKey(legacyWallet.Key, config.ChainCfg)
+		return sequoiaWallet.CreateWalletPrivKey(legacyWallet.Key, types.ChainConfig(config.ChainCfg))
 	}
 
 	err = createWallet(directory)
@@ -112,7 +113,7 @@ func InitWallet(home string) (*wallet.Wallet, error) {
 		return nil, err
 	}
 
-	return sequoiaWallet.CreateWallet(seed.SeedPhrase, seed.DerivationPath, config.ChainCfg)
+	return sequoiaWallet.CreateWallet(seed.SeedPhrase, seed.DerivationPath, types.ChainConfig(config.ChainCfg))
 }
 
 // returns LegacyWallet if "priv_storkey.json" is found at sequoia home directory,

--- a/proofs/proofs.go
+++ b/proofs/proofs.go
@@ -298,7 +298,7 @@ func (p *Prover) Stop() {
 	p.running = false
 }
 
-func NewProver(wallet *wallet.Wallet, q *queue.Queue, io FileSystem, interval int64, threads int64, chunkSize int) *Prover {
+func NewProver(wallet *wallet.Wallet, q *queue.Queue, io FileSystem, interval int64, threads int16, chunkSize int) *Prover {
 	p := Prover{
 		running:   false,
 		wallet:    wallet,

--- a/proofs/types.go
+++ b/proofs/types.go
@@ -16,8 +16,8 @@ type Prover struct {
 	processed      time.Time
 	interval       int64
 	io             FileSystem
-	threads        int64
-	currentThreads int64
+	threads        int16
+	currentThreads int16
 	chunkSize      int
 }
 


### PR DESCRIPTION
Adding viper to bind command flags to config.
Added `mapstructure` tags to unmarshal viper into the Config struct.
Thus, command flag name has to follow the `mapstructure` tag values.
Overall, this enables users to override config file setting via the flags.