### PR TITLE
IPFS parameter support

### DIFF
--- a/api/file_handler.go
+++ b/api/file_handler.go
@@ -10,6 +10,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/JackalLabs/sequoia/utils"
+
 	cid "github.com/ipfs/go-cid"
 
 	"github.com/JackalLabs/sequoia/proofs"
@@ -112,7 +114,7 @@ func PostFileHandler(fio *file_system.FileSystem, prover *proofs.Prover, wl *wal
 			}
 		}
 
-		size, c, err := fio.WriteFile(file, merkle, sender, startBlock, wl.AccAddress(), chunkSize, proofType)
+		size, c, err := fio.WriteFile(file, merkle, sender, startBlock, chunkSize, proofType, utils.GetIPFSParams(&f))
 		if err != nil {
 			handleErr(fmt.Errorf("failed to write file to disk: %w", err), w, http.StatusInternalServerError)
 			return

--- a/file_system/file_system.go
+++ b/file_system/file_system.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"io"
 
+	ipfslite "github.com/hsanjuan/ipfs-lite"
+
 	"github.com/ipfs/boxo/ipld/merkledag"
 
 	"github.com/ipfs/boxo/ipld/unixfs"
@@ -75,7 +77,7 @@ func BuildTree(buf io.Reader, chunkSize int64) ([]byte, []byte, [][]byte, int, e
 	return r, exportedTree, chunks, size, nil
 }
 
-func (f *FileSystem) WriteFile(reader io.Reader, merkle []byte, owner string, start int64, address string, chunkSize int64, proofType int64) (size int, cid string, err error) {
+func (f *FileSystem) WriteFile(reader io.Reader, merkle []byte, owner string, start int64, chunkSize int64, proofType int64, ipfsParams *ipfslite.AddParams) (size int, cid string, err error) {
 	log.Info().Msg(fmt.Sprintf("Writing %x to disk", merkle))
 	root, exportedTree, chunks, s, err := BuildTree(reader, chunkSize)
 	if err != nil {
@@ -107,7 +109,7 @@ func (f *FileSystem) WriteFile(reader io.Reader, merkle []byte, owner string, st
 		}
 		n = folderNode
 	} else {
-		n, err = f.ipfs.AddFile(context.Background(), buf, nil)
+		n, err = f.ipfs.AddFile(context.Background(), buf, ipfsParams)
 		if err != nil {
 			return 0, "", err
 		}

--- a/file_system/file_system_test.go
+++ b/file_system/file_system_test.go
@@ -81,7 +81,7 @@ func BenchmarkFileWrites(b *testing.B) {
 				root, _, _, _, err := BuildTree(buf2, 10240)
 				require.NoError(b, err)
 
-				_, _, err = f.WriteFile(buf, root, "file_owner", 0, "myself", 10240, 0)
+				_, _, err = f.WriteFile(buf, root, "file_owner", 0, 10240, 0, nil)
 				require.NoError(b, err)
 
 			}
@@ -115,7 +115,7 @@ func TestWriteFile(t *testing.T) {
 	m, err := hex.DecodeString(merkle)
 	require.NoError(t, err)
 
-	size, _, err := f.WriteFile(buf, m, "file_owner", 0, "myself", 1024, 0)
+	size, _, err := f.WriteFile(buf, m, "file_owner", 0, 1024, 0, nil)
 
 	require.NoError(t, err)
 
@@ -165,7 +165,7 @@ func TestWriteFileWithDomain(t *testing.T) {
 	m, err := hex.DecodeString(merkle)
 	require.NoError(t, err)
 
-	size, _, err := f.WriteFile(buf, m, "file_owner", 0, "myself", 1024, 0)
+	size, _, err := f.WriteFile(buf, m, "file_owner", 0, 1024, 0, nil)
 
 	require.NoError(t, err)
 
@@ -228,7 +228,7 @@ func TestWriteAndProveFiles(t *testing.T) {
 	owner := "file_owner"
 	var start int64 = 0
 
-	_, _, err = f.WriteFile(b2, root, owner, start, "myself", chunkSize, 0)
+	_, _, err = f.WriteFile(b2, root, owner, start, chunkSize, 0, nil)
 	require.NoError(t, err)
 
 	ms, _, _, err := f.ListFiles()

--- a/file_system/file_system_test.go
+++ b/file_system/file_system_test.go
@@ -4,6 +4,10 @@ package file_system
 import (
 	"io/ioutil"
 
+	"github.com/JackalLabs/sequoia/utils"
+	ipfslite "github.com/hsanjuan/ipfs-lite"
+	"github.com/jackalLabs/canine-chain/v4/x/storage/types"
+
 	"github.com/JackalLabs/sequoia/ipfs"
 )
 
@@ -258,4 +262,109 @@ func TestWriteAndProveFiles(t *testing.T) {
 		require.Equal(t, true, verified)
 
 	}
+}
+
+func TestWriteFileWithParams(t *testing.T) {
+	t.Logf("Starting test: TestWriteFileWithParams")
+	db, err := badger.Open(badger.DefaultOptions("/tmp/badger"))
+	require.NoError(t, err)
+
+	err = db.DropAll()
+	require.NoError(t, err)
+
+	ds, err := ipfs.NewBadgerDataStore(db)
+	require.NoError(t, err)
+
+	f, err := NewFileSystem(context.Background(), db, ds, nil, 4005, "/dns4/ipfs.example.com/tcp/4001")
+	require.NoError(t, err)
+	defer db.Close()
+
+	data, err := hex.DecodeString("303030303030383597631df147918b77139b132d44798cef96879280a4b1e1309f699875c6bf57798d17bbbbe75273ba4343da20d25bbca6729ccf9b1456d0b25a08f9616a7bf414de0e15ed29f0a74378789bc7510a7d1f76348aadd93030303030383032976304f845b5c40413ec580e446491ee9bd7c780e4f2e52cb774995dcd9f10278d5ea5c5b00c2eac37039b7a844fa4a82780d9a4061a99dd1d06e130696afd07dd0e59ec275af66319a71dd53dd89f3bd6381aef3262b1bab5f8115522dbbe67411c87e827fd93d220c9d5bc60f0d55ba12df0ee3ff46ee63ecb1edf540c2aedf9c3fcf42c0310e5f7a5e69df89a0e7961e371c9f1499ccc520e283513b1e5eace184dde615078996ea67d0566b102b6f72baa9c9c76a4cc920d667f82cb55aab33c593538d636a8f1c59aa609f50eb6c20bb52c5885a7cb15cb8a3ada30a53f45ba2a3ad5c321114ffdcb8974eca8f56af3d70956af556165659b9427e078015a4fc55d6ed50a00b3aba89cd00dfdd360b5a82f631eab1be3b7c1d7eceb312733c4b21baa6640e8e5ef683a569625d8f6815858bd24a5e39f2c716862ad3cb77503e131d015f5cb615deb1974b787f85f78e85e14c92b7c8ee217a1cc997ebbb0ed3690d57a01a796692d32bb2c3c6f80af3fb104b1b506e52f94826ed6faed82df260710bb9971d1368724a7fa48c394be60d7435080dc76981c789e458a42dce0f6fe29f4e956768e0eddfff6f512a1a2e64689f82132094249df464c5286014b1835ace7b83dddea38e65e55f818ebc53d929ed38fc0997afb145c036bb1fdc7f1a2813840c69ddc1dc284d18e25b3c9b22619f0a97bcf1f36864ff0ed551e7a7249001b1f909a45b132e6de3585537240dd25941de1e4b66065626f0a2297b5c4328e6b672004e4f16aa4d742bb5b7548c4cc6756d7f2bc0de8df4fe1a21921233dd76785eb319db7bc567f2dbce5be42fdbe853edbdcf36dfbc0996874e096ea4954e4b5afb9751b0bf055778863231b4eb7a0f0839190e26db5cdd2c10f5841edc4cc85b6edf328909886d18b75e4e06210e1020fbb73b51bafdef5cd9a1bd70f52388b00a2bb555bc5e6a06bc88eeb35094a2851f3460305a83b893be857a5452b0728dae28dcd09e8e25a714cf014b557107e911fa16fa1dc6c36e4b1399cd96eca0685dc3746fa19ede15f9c0a14c5b00500b95fba05b8cb29d9c5ee6d2e164ac430e9fe56e59e10681a6f2a647c7ddf0f30ae1308035282c615c8368e")
+	require.NoError(t, err)
+
+	buf := bytes.NewBuffer(data)
+	buf2 := bytes.NewBuffer(buf.Bytes())
+	buf3 := bytes.NewBuffer(buf.Bytes())
+
+	merkle := "1688dc719d1a41ff567fd54e66953f5c518044f6fed6ce814ba777b7dead4ab7d1c193448dc1c04eac05e6708dfd7a8999e9afdf6ba5c525ab7fb9c7f1e2bd4c"
+	m, err := hex.DecodeString(merkle)
+	require.NoError(t, err)
+
+	size, cid1, err := f.WriteFile(buf, m, "file_owner", 0, 1024, 0, nil)
+	require.NoError(t, err)
+	require.Equal(t, len(data), size)
+
+	params := ipfslite.AddParams{
+		Layout:    "balanced",
+		Chunker:   "size-256",
+		RawLeaves: true,
+		Hidden:    false,
+		Shard:     false,
+		NoCopy:    false,
+		HashFun:   "sha2-256",
+	}
+	p, err := json.Marshal(params)
+	require.NoError(t, err)
+	s := make(map[string]string)
+	s["ipfsParams"] = string(p)
+
+	js, err := json.Marshal(s)
+	require.NoError(t, err)
+	uf := types.UnifiedFile{
+		Note: string(js),
+	}
+
+	size, cid2, err := f.WriteFile(buf2, m, "file_owner", 20, 1024, 0, utils.GetIPFSParams(&uf))
+	require.NoError(t, err)
+	require.Equal(t, len(data), size)
+
+	require.NotEqual(t, cid1, cid2)
+
+	params = ipfslite.AddParams{
+		Layout:    "",
+		Chunker:   "",
+		RawLeaves: false,
+		Hidden:    false,
+		Shard:     false,
+		NoCopy:    false,
+		HashFun:   "",
+	}
+	p, err = json.Marshal(params)
+	require.NoError(t, err)
+	s = make(map[string]string)
+	s["ipfsParams"] = string(p)
+
+	js, err = json.Marshal(s)
+	require.NoError(t, err)
+
+	t.Log(string(js))
+
+	uf = types.UnifiedFile{
+		Note: string(js),
+	}
+
+	size, cid3, err := f.WriteFile(buf3, m, "file_owner", 20, 1024, 0, utils.GetIPFSParams(&uf))
+	require.NoError(t, err)
+	require.Equal(t, len(data), size)
+
+	require.Equal(t, cid1, cid3)
+
+	err = db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.PrefetchValues = false
+		it := txn.NewIterator(opts)
+		defer it.Close()
+		for it.Rewind(); it.Valid(); it.Next() {
+			item := it.Item()
+			k := item.Key()
+			log.Info().Msg(fmt.Sprintf("key=%s", k))
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	ms, _, _, err := f.ListFiles()
+	require.NoError(t, err)
+
+	require.Equal(t, 2, len(ms))
 }

--- a/proofs/proofs.go
+++ b/proofs/proofs.go
@@ -276,7 +276,7 @@ func (p *Prover) wrapPostProof(merkle []byte, owner string, start int64, height 
 			}
 		}
 		if err.Error() == ErrNotOurs { // if the file is not ours, delete it
-			log.Info().
+			log.Debug().
 				Hex("merkle", merkle).
 				Str("owner", owner).
 				Int64("start", start).

--- a/recycle/recycle.go
+++ b/recycle/recycle.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/JackalLabs/sequoia/utils"
+
 	"github.com/cosmos/cosmos-sdk/types/query"
 
 	"github.com/JackalLabs/jackal-provider/jprov/archive"
@@ -206,8 +208,8 @@ func (r *RecycleDepot) activateFile(openFile types.UnifiedFile) (size int, cid s
 		openFile.Merkle,
 		openFile.Owner,
 		openFile.Start,
-		"",
-		r.chunkSize, 0)
+		r.chunkSize, 0,
+		utils.GetIPFSParams(&openFile))
 	if err != nil {
 		return 0, "", fmt.Errorf("could not write file | %w", err)
 	}

--- a/strays/hands.go
+++ b/strays/hands.go
@@ -3,6 +3,8 @@ package strays
 import (
 	"time"
 
+	"github.com/JackalLabs/sequoia/utils"
+
 	"github.com/JackalLabs/sequoia/file_system"
 	"github.com/JackalLabs/sequoia/proofs"
 
@@ -39,7 +41,7 @@ func (h *Hand) Start(f *file_system.FileSystem, wallet *wallet.Wallet, myUrl str
 		start := h.stray.Start
 		proofType := h.stray.ProofType
 
-		err := network.DownloadFile(f, merkle, signee, start, wallet, h.stray.FileSize, myUrl, chunkSize, proofType)
+		err := network.DownloadFile(f, merkle, signee, start, wallet, h.stray.FileSize, myUrl, chunkSize, proofType, utils.GetIPFSParams(h.stray))
 		if err != nil {
 			log.Error().Err(err)
 			h.stray = nil

--- a/utils/ipfsParams.go
+++ b/utils/ipfsParams.go
@@ -21,7 +21,10 @@ func GetIPFSParams(file *types.UnifiedFile) *ipfslite.AddParams {
 		return nil
 	}
 
-	ip := ipfsParams.(string)
+	ip, ok := ipfsParams.(string)
+	if !ok {
+		return nil
+	}
 
 	log.Info().Msgf("PARAMS: %s", ip)
 

--- a/utils/ipfsParams.go
+++ b/utils/ipfsParams.go
@@ -1,0 +1,36 @@
+package utils
+
+import (
+	"encoding/json"
+
+	ipfslite "github.com/hsanjuan/ipfs-lite"
+	"github.com/jackalLabs/canine-chain/v4/x/storage/types"
+	"github.com/rs/zerolog/log"
+)
+
+func GetIPFSParams(file *types.UnifiedFile) *ipfslite.AddParams {
+	var data map[string]any
+	err := json.Unmarshal([]byte(file.Note), &data)
+	if err != nil {
+		log.Warn().Msgf("Could not parse note for %x", file.Merkle)
+		return nil
+	}
+
+	ipfsParams, ok := data["ipfsParams"]
+	if !ok {
+		return nil
+	}
+
+	ip := ipfsParams.(string)
+
+	log.Info().Msgf("PARAMS: %s", ip)
+
+	var params ipfslite.AddParams
+	err = json.Unmarshal([]byte(ip), &params)
+	if err != nil {
+		log.Warn().Msgf("Could not parse params from note for %x", file.Merkle)
+		return nil
+	}
+
+	return &params
+}

--- a/utils/ipfsParams_test.go
+++ b/utils/ipfsParams_test.go
@@ -20,7 +20,7 @@ func TestNotes(t *testing.T) {
 		Hidden:    false,
 		Shard:     false,
 		NoCopy:    false,
-		HashFun:   "sha-256",
+		HashFun:   "sha2-256",
 	}
 	p, err := json.Marshal(params)
 	r.NoError(err)

--- a/utils/ipfsParams_test.go
+++ b/utils/ipfsParams_test.go
@@ -1,0 +1,44 @@
+package utils_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/JackalLabs/sequoia/utils"
+	ipfslite "github.com/hsanjuan/ipfs-lite"
+	"github.com/jackalLabs/canine-chain/v4/x/storage/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotes(t *testing.T) {
+	r := require.New(t)
+
+	params := ipfslite.AddParams{
+		Layout:    "balanced",
+		Chunker:   "size-256",
+		RawLeaves: true,
+		Hidden:    false,
+		Shard:     false,
+		NoCopy:    false,
+		HashFun:   "sha-256",
+	}
+	p, err := json.Marshal(params)
+	r.NoError(err)
+
+	s := make(map[string]string)
+	s["ipfsParams"] = string(p)
+
+	js, err := json.Marshal(s)
+	r.NoError(err)
+
+	f := types.UnifiedFile{
+		Note: string(js),
+	}
+
+	pars := utils.GetIPFSParams(&f)
+	t.Log(pars)
+
+	r.NotNil(pars)
+
+	r.Equal(params, *pars)
+}


### PR DESCRIPTION
We've been unable to add every IPFS file directly because of some incompatibilities in the IPFS adding parameters, whether this be chunkers or hash types, even raw leaves. This makes that possible by embedding the data directly into the file object on chain with notes.