### PR TITLE
confirm termination with y/n

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ data
 /.idea/
 /coverage.txt
 *.log
+sequoia

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -68,11 +68,9 @@ func askForConfirmation(s string) bool {
 		response = strings.ToLower(strings.TrimSpace(response))
 
 		switch response {
-		case "y":
-		case "yes":
+		case "y", "yes":
 			return true
-		case "n":
-		case "no":
+		case "n", "no":
 			return false
 		}
 	}


### PR DESCRIPTION
the previous syntax was wrong and resulted in nothing happening when the user entered y or n
![image](https://github.com/user-attachments/assets/86119f1c-51ad-4e31-a25a-dd8e3b27ee10)
https://go.dev/wiki/Switch
![image](https://github.com/user-attachments/assets/cf2ed2a2-d52e-4996-8bff-222816268e44)
