### PR TITLE
Add failover support for multiple RPC nodes

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -5,15 +5,16 @@ import (
 	"net/http"
 
 	"github.com/JackalLabs/sequoia/api/types"
+	"github.com/JackalLabs/sequoia/rpc"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	"github.com/desmos-labs/cosmos-go-wallet/client"
 	storageTypes "github.com/jackalLabs/canine-chain/v5/x/storage/types"
 	"github.com/rs/zerolog/log"
 )
 
-func SpaceHandler(c *client.Client, address string) func(http.ResponseWriter, *http.Request) {
+func SpaceHandler(fc *rpc.FailoverClient) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
-		queryClient := storageTypes.NewQueryClient(c.GRPCConn)
+		queryClient := storageTypes.NewQueryClient(fc.GRPCConn())
+		address := fc.AccAddress()
 
 		params := &storageTypes.QueryProvider{
 			Address: address,

--- a/api/index.go
+++ b/api/index.go
@@ -5,9 +5,9 @@ import (
 	"net/http"
 
 	"github.com/JackalLabs/sequoia/config"
+	"github.com/JackalLabs/sequoia/rpc"
 
 	"github.com/JackalLabs/sequoia/api/types"
-	"github.com/desmos-labs/cosmos-go-wallet/wallet"
 	"github.com/rs/zerolog/log"
 )
 
@@ -26,9 +26,9 @@ func IndexHandler(address string) func(http.ResponseWriter, *http.Request) {
 	}
 }
 
-func VersionHandler(wallet *wallet.Wallet) func(http.ResponseWriter, *http.Request) {
+func VersionHandler(fc *rpc.FailoverClient) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
-		chainId, err := wallet.Client.GetChainID()
+		chainId, err := fc.Wallet().Client.GetChainID()
 		if err != nil {
 			w.WriteHeader(500)
 			return
@@ -48,15 +48,15 @@ func VersionHandler(wallet *wallet.Wallet) func(http.ResponseWriter, *http.Reque
 	}
 }
 
-func NetworkHandler(wallet *wallet.Wallet) func(http.ResponseWriter, *http.Request) {
+func NetworkHandler(fc *rpc.FailoverClient) func(http.ResponseWriter, *http.Request) {
 	return func(w http.ResponseWriter, req *http.Request) {
-		status, err := wallet.Client.RPCClient.Status(context.Background())
+		status, err := fc.RPCClient().Status(context.Background())
 		if err != nil {
 			w.WriteHeader(500)
 			return
 		}
 
-		grpcStatus := wallet.Client.GRPCConn.GetState()
+		grpcStatus := fc.GRPCConn().GetState()
 
 		v := types.NetworkResponse{
 			GRPCStatus: grpcStatus.String(),

--- a/cmd/wallet/wallet.go
+++ b/cmd/wallet/wallet.go
@@ -65,16 +65,16 @@ func balanceCMD() *cobra.Command {
 				return err
 			}
 
-			wallet, err := config.InitWallet(home)
+			fc, err := config.InitWallet(home)
 			if err != nil {
 				return err
 			}
 
-			queryClient := bankTypes.NewQueryClient(wallet.Client.GRPCConn)
+			queryClient := bankTypes.NewQueryClient(fc.GRPCConn())
 
 			params := &bankTypes.QueryBalanceRequest{
 				Denom:   "ujkl",
-				Address: wallet.AccAddress(),
+				Address: fc.AccAddress(),
 			}
 
 			res, err := queryClient.Balance(context.Background(), params)
@@ -125,7 +125,7 @@ func withdrawCMD() *cobra.Command {
 				&m,
 			).WithGasAuto().WithFeeAuto()
 
-			res, err := wallet.BroadcastTxCommit(data)
+			res, err := wallet.Wallet().BroadcastTxCommit(data)
 			if err != nil {
 				return err
 			}

--- a/monitoring/monitor.go
+++ b/monitoring/monitor.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (m *Monitor) updateBurns() {
-	cl := types.NewQueryClient(m.wallet.Client.GRPCConn)
+	cl := types.NewQueryClient(m.wallet.GRPCConn())
 	provRes, err := cl.Provider(context.Background(), &types.QueryProvider{Address: m.wallet.AccAddress()})
 	if err != nil {
 		return
@@ -27,7 +27,7 @@ func (m *Monitor) updateBurns() {
 }
 
 func (m *Monitor) updateHeight() {
-	abciInfo, err := m.wallet.Client.RPCClient.ABCIInfo(context.Background())
+	abciInfo, err := m.wallet.RPCClient().ABCIInfo(context.Background())
 	if err != nil {
 		return
 	}
@@ -37,7 +37,7 @@ func (m *Monitor) updateHeight() {
 }
 
 func (m *Monitor) updateBalance() {
-	cl := bankTypes.NewQueryClient(m.wallet.Client.GRPCConn)
+	cl := bankTypes.NewQueryClient(m.wallet.GRPCConn())
 	provRes, err := cl.Balance(context.Background(), &bankTypes.QueryBalanceRequest{Address: m.wallet.AccAddress(), Denom: "ujkl"})
 	if err != nil {
 		return

--- a/monitoring/types.go
+++ b/monitoring/types.go
@@ -1,7 +1,7 @@
 package monitoring
 
 import (
-	"github.com/desmos-labs/cosmos-go-wallet/wallet"
+	"github.com/JackalLabs/sequoia/rpc"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
@@ -30,10 +30,10 @@ var _ = catchingUp
 
 type Monitor struct {
 	running bool
-	wallet  *wallet.Wallet
+	wallet  *rpc.FailoverClient
 }
 
-func NewMonitor(wallet *wallet.Wallet) *Monitor {
+func NewMonitor(wallet *rpc.FailoverClient) *Monitor {
 	return &Monitor{
 		running: false,
 		wallet:  wallet,

--- a/proofs/types.go
+++ b/proofs/types.go
@@ -6,12 +6,12 @@ import (
 	merkletree "github.com/wealdtech/go-merkletree/v2"
 
 	"github.com/JackalLabs/sequoia/queue"
-	"github.com/desmos-labs/cosmos-go-wallet/wallet"
+	"github.com/JackalLabs/sequoia/rpc"
 )
 
 type Prover struct {
 	running        bool
-	wallet         *wallet.Wallet
+	wallet         *rpc.FailoverClient
 	q              *queue.Queue
 	processed      time.Time
 	interval       uint64

--- a/queue/queue.go
+++ b/queue/queue.go
@@ -12,11 +12,11 @@ import (
 	"time"
 
 	"github.com/JackalLabs/sequoia/config"
+	"github.com/JackalLabs/sequoia/rpc"
 	storageTypes "github.com/jackalLabs/canine-chain/v5/x/storage/types"
 
 	"github.com/cosmos/cosmos-sdk/types"
 	walletTypes "github.com/desmos-labs/cosmos-go-wallet/types"
-	"github.com/desmos-labs/cosmos-go-wallet/wallet"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/time/rate"
 )
@@ -71,7 +71,7 @@ func (m *Message) Done() {
 	m.wg.Done()
 }
 
-func NewQueue(w *wallet.Wallet, interval uint64, maxSizeBytes int64, domain string, rlCfg config.RateLimitConfig) *Queue {
+func NewQueue(w *rpc.FailoverClient, interval uint64, maxSizeBytes int64, domain string, rlCfg config.RateLimitConfig) *Queue {
 	if maxSizeBytes == 0 {
 		maxSizeBytes = config.DefaultMaxSizeBytes()
 	}
@@ -174,8 +174,12 @@ func (q *Queue) BroadcastPending() (int, error) {
 	log.Info().Msg(fmt.Sprintf("Queue: %d messages waiting to be put on-chain...", total))
 
 	limit := 5000
-	unconfirmedTxs, err := q.wallet.Client.RPCClient.UnconfirmedTxs(context.Background(), &limit)
+	unconfirmedTxs, err := q.wallet.RPCClient().UnconfirmedTxs(context.Background(), &limit)
 	if err != nil {
+		if rpc.IsConnectionError(err) {
+			log.Warn().Err(err).Msg("Connection error getting mempool status, attempting failover")
+			q.wallet.Failover()
+		}
 		log.Error().Err(err).Msg("could not get mempool status")
 		return 0, err
 	}
@@ -231,8 +235,15 @@ func (q *Queue) BroadcastPending() (int, error) {
 	var i int
 	for !complete && i < 10 {
 		i++
-		res, err = q.wallet.BroadcastTxSync(data)
+		w := q.wallet.Wallet()
+		res, err = w.BroadcastTxSync(data)
 		if err != nil {
+			if rpc.IsConnectionError(err) {
+				log.Warn().Err(err).Msg("Connection error during broadcast, attempting failover")
+				if q.wallet.Failover() {
+					continue // Retry with new connection
+				}
+			}
 			if strings.Contains(err.Error(), "tx already exists in cache") {
 				log.Info().Msg("TX already exists in mempool, we're going to skip it.")
 				continue

--- a/queue/types.go
+++ b/queue/types.go
@@ -4,13 +4,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/JackalLabs/sequoia/rpc"
 	"github.com/cosmos/cosmos-sdk/types"
-	"github.com/desmos-labs/cosmos-go-wallet/wallet"
 	"golang.org/x/time/rate"
 )
 
 type Queue struct {
-	wallet       *wallet.Wallet
+	wallet       *rpc.FailoverClient
 	messages     []*Message
 	processed    time.Time
 	running      bool

--- a/rpc/failover.go
+++ b/rpc/failover.go
@@ -17,6 +17,9 @@ import (
 // ErrNoNodes is returned when no RPC/GRPC nodes are configured.
 var ErrNoNodes = errors.New("no RPC/GRPC nodes configured")
 
+// ErrMismatchedNodeCounts is returned when RPCAddrs and GRPCAddrs have different lengths.
+var ErrMismatchedNodeCounts = errors.New("RPCAddrs and GRPCAddrs must have the same length")
+
 // ErrInvalidNodeIndex is returned when an invalid node index is provided.
 var ErrInvalidNodeIndex = errors.New("invalid node index")
 
@@ -59,6 +62,9 @@ func NewFailoverClient(nodeCfg NodeConfig, seed, derivation string) (*FailoverCl
 	if len(nodeCfg.RPCAddrs) == 0 || len(nodeCfg.GRPCAddrs) == 0 {
 		return nil, ErrNoNodes
 	}
+	if len(nodeCfg.RPCAddrs) != len(nodeCfg.GRPCAddrs) {
+		return nil, ErrMismatchedNodeCounts
+	}
 
 	fc := &FailoverClient{
 		nodeCfg:      nodeCfg,
@@ -79,6 +85,9 @@ func NewFailoverClient(nodeCfg NodeConfig, seed, derivation string) (*FailoverCl
 func NewFailoverClientWithPrivKey(nodeCfg NodeConfig, privKey string) (*FailoverClient, error) {
 	if len(nodeCfg.RPCAddrs) == 0 || len(nodeCfg.GRPCAddrs) == 0 {
 		return nil, ErrNoNodes
+	}
+	if len(nodeCfg.RPCAddrs) != len(nodeCfg.GRPCAddrs) {
+		return nil, ErrMismatchedNodeCounts
 	}
 
 	fc := &FailoverClient{

--- a/rpc/failover.go
+++ b/rpc/failover.go
@@ -1,0 +1,368 @@
+package rpc
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	sequoiaWallet "github.com/JackalLabs/sequoia/wallet"
+	"github.com/cosmos/gogoproto/grpc"
+	walletTypes "github.com/desmos-labs/cosmos-go-wallet/types"
+	"github.com/desmos-labs/cosmos-go-wallet/wallet"
+	"github.com/rs/zerolog/log"
+	"github.com/tendermint/tendermint/rpc/client"
+)
+
+// NodeConfig contains the configuration needed to connect to blockchain nodes.
+// This is separate from config.ChainConfig to avoid import cycles.
+type NodeConfig struct {
+	Bech32Prefix  string
+	RPCAddrs      []string
+	GRPCAddrs     []string
+	GasPrice      string
+	GasAdjustment float64
+}
+
+// FailoverClient wraps a wallet and provides automatic failover between
+// multiple RPC/GRPC nodes. When a connection error is detected, it
+// automatically switches to the next available node.
+type FailoverClient struct {
+	mu sync.RWMutex
+
+	wallet *wallet.Wallet
+
+	// Configuration
+	nodeCfg      NodeConfig
+	seed         string
+	derivation   string
+	useLegacyKey bool
+	legacyKey    string
+
+	// Node tracking
+	rpcAddrs      []string
+	grpcAddrs     []string
+	currentIndex  int
+	lastFailover  time.Time
+	failoverCount int
+}
+
+// NewFailoverClient creates a new FailoverClient with the given configuration.
+// It initializes the first connection using the provided seed phrase.
+func NewFailoverClient(nodeCfg NodeConfig, seed, derivation string) (*FailoverClient, error) {
+	fc := &FailoverClient{
+		nodeCfg:      nodeCfg,
+		seed:         seed,
+		derivation:   derivation,
+		useLegacyKey: false,
+		rpcAddrs:     nodeCfg.RPCAddrs,
+		grpcAddrs:    nodeCfg.GRPCAddrs,
+		currentIndex: 0,
+	}
+
+	// Create initial wallet connection
+	w, err := fc.createWalletAtIndex(0)
+	if err != nil {
+		// Try other nodes if the first one fails
+		for i := 1; i < len(fc.rpcAddrs); i++ {
+			w, err = fc.createWalletAtIndex(i)
+			if err == nil {
+				fc.currentIndex = i
+				break
+			}
+			log.Warn().Err(err).Int("index", i).Msg("Failed to connect to node, trying next")
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	fc.wallet = w
+	log.Info().
+		Int("node_index", fc.currentIndex).
+		Str("rpc", fc.rpcAddrs[fc.currentIndex]).
+		Str("grpc", fc.grpcAddrs[fc.currentIndex]).
+		Msg("Connected to blockchain node")
+
+	return fc, nil
+}
+
+// NewFailoverClientWithPrivKey creates a new FailoverClient using a legacy private key.
+func NewFailoverClientWithPrivKey(nodeCfg NodeConfig, privKey string) (*FailoverClient, error) {
+	fc := &FailoverClient{
+		nodeCfg:      nodeCfg,
+		useLegacyKey: true,
+		legacyKey:    privKey,
+		rpcAddrs:     nodeCfg.RPCAddrs,
+		grpcAddrs:    nodeCfg.GRPCAddrs,
+		currentIndex: 0,
+	}
+
+	// Create initial wallet connection
+	w, err := fc.createWalletAtIndex(0)
+	if err != nil {
+		// Try other nodes if the first one fails
+		for i := 1; i < len(fc.rpcAddrs); i++ {
+			w, err = fc.createWalletAtIndex(i)
+			if err == nil {
+				fc.currentIndex = i
+				break
+			}
+			log.Warn().Err(err).Int("index", i).Msg("Failed to connect to node, trying next")
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	fc.wallet = w
+	log.Info().
+		Int("node_index", fc.currentIndex).
+		Str("rpc", fc.rpcAddrs[fc.currentIndex]).
+		Str("grpc", fc.grpcAddrs[fc.currentIndex]).
+		Msg("Connected to blockchain node")
+
+	return fc, nil
+}
+
+// createWalletAtIndex creates a new wallet connection using the node at the given index.
+func (fc *FailoverClient) createWalletAtIndex(index int) (*wallet.Wallet, error) {
+	if index >= len(fc.rpcAddrs) || index >= len(fc.grpcAddrs) {
+		index = 0
+	}
+
+	// Create a modified chain config with the specific node addresses
+	chainCfg := walletTypes.ChainConfig{
+		Bech32Prefix:  fc.nodeCfg.Bech32Prefix,
+		RPCAddr:       fc.rpcAddrs[index],
+		GRPCAddr:      fc.grpcAddrs[index],
+		GasPrice:      fc.nodeCfg.GasPrice,
+		GasAdjustment: fc.nodeCfg.GasAdjustment,
+	}
+
+	if fc.useLegacyKey {
+		return sequoiaWallet.CreateWalletPrivKey(fc.legacyKey, chainCfg)
+	}
+	return sequoiaWallet.CreateWallet(fc.seed, fc.derivation, chainCfg)
+}
+
+// Failover switches to the next available node. Returns true if a new node
+// was connected, false if we've cycled through all nodes without success.
+func (fc *FailoverClient) Failover() bool {
+	fc.mu.Lock()
+	defer fc.mu.Unlock()
+
+	startIndex := fc.currentIndex
+	totalNodes := len(fc.rpcAddrs)
+
+	for i := 1; i <= totalNodes; i++ {
+		nextIndex := (startIndex + i) % totalNodes
+		log.Info().
+			Int("from_index", fc.currentIndex).
+			Int("to_index", nextIndex).
+			Str("rpc", fc.rpcAddrs[nextIndex]).
+			Str("grpc", fc.grpcAddrs[nextIndex]).
+			Msg("Attempting failover to next node")
+
+		w, err := fc.createWalletAtIndex(nextIndex)
+		if err != nil {
+			log.Warn().Err(err).
+				Int("index", nextIndex).
+				Str("rpc", fc.rpcAddrs[nextIndex]).
+				Msg("Failed to connect during failover, trying next")
+			continue
+		}
+
+		fc.wallet = w
+		fc.currentIndex = nextIndex
+		fc.lastFailover = time.Now()
+		fc.failoverCount++
+
+		log.Info().
+			Int("node_index", fc.currentIndex).
+			Str("rpc", fc.rpcAddrs[fc.currentIndex]).
+			Str("grpc", fc.grpcAddrs[fc.currentIndex]).
+			Int("total_failovers", fc.failoverCount).
+			Msg("Successfully failed over to new node")
+
+		return true
+	}
+
+	log.Error().Msg("Failed to connect to any node during failover")
+	return false
+}
+
+// Wallet returns the underlying wallet. Use with caution - prefer using
+// the FailoverClient methods which handle automatic failover.
+func (fc *FailoverClient) Wallet() *wallet.Wallet {
+	fc.mu.RLock()
+	defer fc.mu.RUnlock()
+	return fc.wallet
+}
+
+// GRPCConn returns the current GRPC connection.
+func (fc *FailoverClient) GRPCConn() grpc.ClientConn {
+	fc.mu.RLock()
+	defer fc.mu.RUnlock()
+	return fc.wallet.Client.GRPCConn
+}
+
+// RPCClient returns the current RPC client.
+func (fc *FailoverClient) RPCClient() client.Client {
+	fc.mu.RLock()
+	defer fc.mu.RUnlock()
+	return fc.wallet.Client.RPCClient
+}
+
+// AccAddress returns the account address.
+func (fc *FailoverClient) AccAddress() string {
+	fc.mu.RLock()
+	defer fc.mu.RUnlock()
+	return fc.wallet.AccAddress()
+}
+
+// CurrentNodeIndex returns the index of the currently connected node.
+func (fc *FailoverClient) CurrentNodeIndex() int {
+	fc.mu.RLock()
+	defer fc.mu.RUnlock()
+	return fc.currentIndex
+}
+
+// CurrentRPCAddr returns the RPC address of the currently connected node.
+func (fc *FailoverClient) CurrentRPCAddr() string {
+	fc.mu.RLock()
+	defer fc.mu.RUnlock()
+	return fc.rpcAddrs[fc.currentIndex]
+}
+
+// CurrentGRPCAddr returns the GRPC address of the currently connected node.
+func (fc *FailoverClient) CurrentGRPCAddr() string {
+	fc.mu.RLock()
+	defer fc.mu.RUnlock()
+	return fc.grpcAddrs[fc.currentIndex]
+}
+
+// FailoverCount returns the total number of failovers that have occurred.
+func (fc *FailoverClient) FailoverCount() int {
+	fc.mu.RLock()
+	defer fc.mu.RUnlock()
+	return fc.failoverCount
+}
+
+// NodeCount returns the total number of configured nodes.
+func (fc *FailoverClient) NodeCount() int {
+	return len(fc.rpcAddrs)
+}
+
+// IsConnectionError checks if an error indicates a connection problem that
+// should trigger a failover.
+func IsConnectionError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	errStr := err.Error()
+
+	// Common connection error patterns
+	connectionErrors := []string{
+		"connection refused",
+		"connection reset",
+		"no such host",
+		"network is unreachable",
+		"i/o timeout",
+		"context deadline exceeded",
+		"EOF",
+		"connection closed",
+		"transport is closing",
+		"server misbehaving",
+		"unavailable",
+		"failed to connect",
+	}
+
+	for _, pattern := range connectionErrors {
+		if contains(errStr, pattern) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// contains checks if s contains substr (case-insensitive).
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsIgnoreCase(s, substr))
+}
+
+func containsIgnoreCase(s, substr string) bool {
+	s = toLowerCase(s)
+	substr = toLowerCase(substr)
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
+func toLowerCase(s string) string {
+	b := make([]byte, len(s))
+	for i := range s {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		b[i] = c
+	}
+	return string(b)
+}
+
+// ExecuteWithFailover executes a function and automatically fails over
+// to the next node if a connection error is detected.
+func (fc *FailoverClient) ExecuteWithFailover(fn func() error) error {
+	err := fn()
+	if err != nil && IsConnectionError(err) {
+		log.Warn().Err(err).Msg("Connection error detected, attempting failover")
+		if fc.Failover() {
+			// Retry after failover
+			return fn()
+		}
+	}
+	return err
+}
+
+// QueryWithFailover executes a query function and automatically fails over
+// to the next node if a connection error is detected. It returns the result
+// of the query function.
+func QueryWithFailover[T any](fc *FailoverClient, fn func() (T, error)) (T, error) {
+	result, err := fn()
+	if err != nil && IsConnectionError(err) {
+		log.Warn().Err(err).Msg("Connection error detected during query, attempting failover")
+		if fc.Failover() {
+			// Retry after failover
+			return fn()
+		}
+	}
+	return result, err
+}
+
+// HealthCheck performs a health check on the current node by querying ABCI info.
+func (fc *FailoverClient) HealthCheck(ctx context.Context) error {
+	fc.mu.RLock()
+	rpcClient := fc.wallet.Client.RPCClient
+	fc.mu.RUnlock()
+
+	_, err := rpcClient.ABCIInfo(ctx)
+	return err
+}
+
+// EnsureHealthy checks if the current node is healthy, and if not,
+// attempts to failover to a healthy node.
+func (fc *FailoverClient) EnsureHealthy(ctx context.Context) error {
+	err := fc.HealthCheck(ctx)
+	if err != nil {
+		log.Warn().Err(err).Msg("Current node unhealthy, attempting failover")
+		if !fc.Failover() {
+			return err
+		}
+	}
+	return nil
+}

--- a/rpc/failover.go
+++ b/rpc/failover.go
@@ -2,6 +2,7 @@ package rpc
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"time"
 
@@ -278,41 +279,14 @@ func IsConnectionError(err error) bool {
 		"failed to connect",
 	}
 
+	errStrLower := strings.ToLower(errStr)
 	for _, pattern := range connectionErrors {
-		if contains(errStr, pattern) {
+		if strings.Contains(errStrLower, pattern) {
 			return true
 		}
 	}
 
 	return false
-}
-
-// contains checks if s contains substr (case-insensitive).
-func contains(s, substr string) bool {
-	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsIgnoreCase(s, substr))
-}
-
-func containsIgnoreCase(s, substr string) bool {
-	s = toLowerCase(s)
-	substr = toLowerCase(substr)
-	for i := 0; i <= len(s)-len(substr); i++ {
-		if s[i:i+len(substr)] == substr {
-			return true
-		}
-	}
-	return false
-}
-
-func toLowerCase(s string) string {
-	b := make([]byte, len(s))
-	for i := range s {
-		c := s[i]
-		if c >= 'A' && c <= 'Z' {
-			c += 'a' - 'A'
-		}
-		b[i] = c
-	}
-	return string(b)
 }
 
 // ExecuteWithFailover executes a function and automatically fails over

--- a/strays/hands.go
+++ b/strays/hands.go
@@ -115,7 +115,7 @@ func (h *Hand) Take(stray *types.UnifiedFile) {
 func (s *StrayManager) NewHand(q *queue.Queue) (*Hand, error) {
 	offset := byte(len(s.hands)) + 1
 
-	w, err := s.wallet.CloneWalletOffset(offset)
+	w, err := s.wallet.Wallet().CloneWalletOffset(offset)
 	if err != nil {
 		return nil, err
 	}

--- a/strays/types.go
+++ b/strays/types.go
@@ -4,6 +4,7 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/JackalLabs/sequoia/rpc"
 	"github.com/desmos-labs/cosmos-go-wallet/wallet"
 	"github.com/jackalLabs/canine-chain/v5/x/storage/types"
 )
@@ -17,7 +18,7 @@ type Hand struct {
 
 type StrayManager struct {
 	strays          []*types.UnifiedFile
-	wallet          *wallet.Wallet
+	wallet          *rpc.FailoverClient
 	lastSize        uint64
 	rand            *rand.Rand
 	interval        time.Duration


### PR DESCRIPTION
Implement automatic failover capability for multiple RPC/GRPC nodes:

- Add RPCAddrs/GRPCAddrs fields to ChainConfig with backwards compatibility
- Create new rpc/failover.go package with FailoverClient wrapper
- FailoverClient automatically switches to next available node on connection errors
- Add IsConnectionError() helper to detect connection failures
- Update all components to use FailoverClient instead of direct wallet

The failover state is kept in memory only. When a connection error is detected, the system automatically attempts to connect to the next configured node in the list.

Configuration example:
  chain:
    rpc_addrs:
      - http://node1:26657
      - http://node2:26657 grpc_addrs: - node1:9090 - node2:9090

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a failover RPC client with multi-node RPC/GRPC support, health checks and automatic failover.

* **Improvements**
  * Core services, API endpoints, CLI, monitoring, proof generation, queueing and stray management now use the failover client for more reliable connectivity.
  * Automatic retries on connection errors, improved mempool/broadcast handling, and multi-address configuration for RPC/GRPC redundancy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->